### PR TITLE
log -> logrus

### DIFF
--- a/internal/clients/correlation_id.go
+++ b/internal/clients/correlation_id.go
@@ -1,7 +1,7 @@
 package clients
 
 import (
-	"log"
+	log "github.com/sirupsen/logrus"
 	"sync"
 
 	"github.com/Azure/go-autorest/autorest"

--- a/internal/provider/resource_cluster.go
+++ b/internal/provider/resource_cluster.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_cluster_root_token.go
+++ b/internal/provider/resource_cluster_root_token.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strings"
 	"time"
 

--- a/internal/provider/resource_snapshot.go
+++ b/internal/provider/resource_snapshot.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"context"
-	"log"
+	log "github.com/sirupsen/logrus"
 	"strconv"
 	"time"
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/hashicorp/terraform-provider-hcs/internal/provider"


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)